### PR TITLE
chore(deps): add missing repository setting, reuse workspace config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 categories = ["os", "os::linux-apis"]
 keywords = ["v4l", "v4l2", "video", "linux", "ioctl"]
 edition = "2021"
+repository = "https://github.com/katyo/linux-video-rs"
 
 [workspace]
 members = ["core", "tokio", "async-std", "cli"]

--- a/async-std/Cargo.toml
+++ b/async-std/Cargo.toml
@@ -2,12 +2,14 @@
 name = "async-std-linux-video"
 description = "Linux V4L2 device interfacing with async-std"
 version = "0.1.1"
-authors = ["K. <kayo@illumium.org>"]
-license = "MIT"
-readme = "README.md"
 categories = ["os", "os::linux-apis", "asynchronous"]
 keywords = ["v4l", "v4l2", "linux", "async", "async-std"]
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies.linux-video-core]
 path = "../core"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,13 +2,15 @@
 name = "linux-video-cli"
 description = "Linux video device interfacing (utils)"
 version = "0.1.0"
-authors = ["K. <kayo@illumium.org>"]
-license = "MIT"
-readme = "README.md"
 categories = ["command-line-utilities"]
 keywords = ["v4l", "v4l2", "video", "linux", "ioctl"]
-edition = "2021"
 publish = false
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "video-cli"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,12 +2,14 @@
 name = "linux-video-core"
 description = "Linux V4L2 device interfacing"
 version = "0.1.1"
-authors = ["K. <kayo@illumium.org>"]
-license = "MIT"
-readme = "README.md"
 categories = ["os", "os::linux-apis"]
 keywords = ["v4l", "v4l2", "video", "linux", "ioctl"]
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies.bitmask-enum]
 version = "2"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -2,12 +2,14 @@
 name = "tokio-linux-video"
 description = "Linux V4L2 device interfacing with tokio"
 version = "0.1.1"
-authors = ["K. <kayo@illumium.org>"]
-license = "MIT"
-readme = "README.md"
 categories = ["os", "os::linux-apis", "asynchronous"]
 keywords = ["v4l", "v4l2", "linux", "async", "tokio"]
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 
 [dependencies.linux-video-core]
 path = "../core"


### PR DESCRIPTION
This commit adds the missing `repository` setting to all Cargo.toml files in the repository so that people can easily find the code from crates.io and other places.

Along with adding repository, a small refactor to reuse the workspace configuration where it made sense.